### PR TITLE
Add `gemini-2.5-pro` to thinking models

### DIFF
--- a/apa/configuration_thinking_models.toml
+++ b/apa/configuration_thinking_models.toml
@@ -1,0 +1,12 @@
+stream = true
+
+programming_language = "Python"
+thinking_tokens  = 16384
+
+# default model to send to LiteLLM (overrides provider-specific default)
+provider = "openrouter" # Could be openai, anthropic, deepseek or openrouter
+model = "google/gemini-2.5-pro" # Should be o3, o3-pro-2025-06-10, o4-mini, claude-sonnet-4-20250514, claude-opus-4-20250514, deepseek-reasoner
+
+# fallback configuration
+fallback_provider = "anthropic"
+fallback_model = "claude-sonnet-4-20250514"

--- a/apa/infrastructure/llm_client.py
+++ b/apa/infrastructure/llm_client.py
@@ -60,13 +60,15 @@ SUPPORT_DEVELOPER_MESSAGE_MODELS = frozenset({
     "gpt-4.1-2025-04-14",
 })
 
-CLAUDE_EXTENDED_THINKING_MODELS = frozenset({
+EXTENDED_THINKING_MODELS = frozenset({
     "anthropic/claude-3-7-sonnet-20250219",
     "claude-3-7-sonnet-20250219",
     "anthropic/claude-sonnet-4-20250514",
     "claude-sonnet-4-20250514",
     "anthropic/claude-opus-4-20250514",
     "claude-opus-4-20250514",
+    "gemini/gemini-2.5-pro",
+    "openrouter/google/gemini-2.5-pro",
 })
 
 # providers the app currently supports
@@ -112,7 +114,7 @@ def _prepare_completion_kwargs(
         kwargs["reasoning_effort"] = cfg.reasoning_effort
 
     # Claude thinking tokens handling
-    if provider_config.model in CLAUDE_EXTENDED_THINKING_MODELS and cfg.thinking_tokens:
+    if provider_config.model in EXTENDED_THINKING_MODELS and cfg.thinking_tokens:
         logger.info(f"Adding thinking_tokens={cfg.thinking_tokens}")
         kwargs["thinking"] = {
             "type": "enabled",

--- a/apa/infrastructure/llm_client.py
+++ b/apa/infrastructure/llm_client.py
@@ -114,7 +114,7 @@ def _prepare_completion_kwargs(
         kwargs["reasoning_effort"] = cfg.reasoning_effort
 
     # Claude thinking tokens handling
-    if provider_config.model in EXTENDED_THINKING_MODELS and cfg.thinking_tokens:
+    if (provider_config.model in EXTENDED_THINKING_MODELS or f'{provider_config.provider}/{provider_config.model}' in EXTENDED_THINKING_MODELS) and cfg.thinking_tokens:
         logger.info(f"Adding thinking_tokens={cfg.thinking_tokens}")
         kwargs["thinking"] = {
             "type": "enabled",

--- a/apa/services/__init__.py
+++ b/apa/services/__init__.py
@@ -1,1 +1,0 @@
-from apa.infrastructure.llm_client import acompletion  # noqa: F401

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import argparse, asyncio, pathlib, sys
-from apa.services import acompletion
 from apa.config     import load_settings
+from apa.infrastructure.llm_client import acompletion
 
 def _parse_args() -> argparse.Namespace:
     """Parse command line arguments for the APA application.


### PR DESCRIPTION
### **PR Type**
Feature, Enhancement

___

### **PR Description**
- Added `gemini-2.5-pro` to extended thinking models.

- Updated model check logic to support provider-prefixed models.

- Created new configuration file for `gemini-2.5-pro` settings.

- Fixed import structure in `main.py`.
