### PR TITLE
Add support `gpt-5-2025-08-07` and `claude-opus-4-1-20250805`

### DIFF
--- a/apa/configuration.toml
+++ b/apa/configuration.toml
@@ -3,9 +3,9 @@ stream = true
 programming_language = "Python"
 reasoning_effort = "high"
 
-provider = "openrouter"
-model = "qwen/qwen3-235b-a22b-thinking-2507"
+provider = "openai"
+model = "gpt-5-2025-08-07"
 
 # fallback configuration
-fallback_provider = "openai"
-fallback_model = "o3"
+fallback_provider = "openrouter"
+fallback_model = "qwen/qwen3-235b-a22b-thinking-2507"

--- a/apa/infrastructure/llm/llm_client.py
+++ b/apa/infrastructure/llm/llm_client.py
@@ -21,6 +21,8 @@ class LLMClient:
         "o3-2025-04-16",
         "o4-mini",
         "o4-mini-2025-04-16",
+        "gpt-5-2025-08-07",
+        "gpt-5",
     })
 
     SUPPORT_REASONING_EFFORT_MODELS = frozenset({
@@ -30,7 +32,9 @@ class LLMClient:
         "o3-2025-04-16",
         "o4-mini",
         "o4-mini-2025-04-16",
-        "qwen/qwen3-235b-a22b-thinking-2507"
+        "qwen/qwen3-235b-a22b-thinking-2507",
+        "gpt-5-2025-08-07",
+        "gpt-5",
     })
 
     SUPPORT_DEVELOPER_MESSAGE_MODELS = frozenset({
@@ -46,6 +50,8 @@ class LLMClient:
         "o4-mini-2025-04-16",
         "gpt-4.1",
         "gpt-4.1-2025-04-14",
+        "gpt-5-2025-08-07",
+        "gpt-5",
     })
 
     EXTENDED_THINKING_MODELS = frozenset({
@@ -57,6 +63,8 @@ class LLMClient:
         "claude-opus-4-20250514",
         "gemini/gemini-2.5-pro",
         "google/gemini-2.5-pro",
+        "claude-opus-4-1-20250805",
+        "anthropic/claude-opus-4-1-20250805",
     })
 
     # Providers that support the reasoning_effort parameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name        = "apa"
-version     = "0.3.2"
+version     = "0.3.3"
 description = "Async Prompt Application powered by LiteLLM"
 authors     = [{ name = "Kenny Dizi", email = "chitrung09t2@gmail.com" }]
 dependencies = [
-    "litellm==1.75.0",
+    "litellm[proxy]==1.75.2",
     "tiktoken==0.10.0",
     "tenacity==9.1.2",
-    "anthropic==0.61.0",
+    "anthropic==0.62.0",
     "tomli==2.2.1",
     "jiter==0.10.0",
     "pydantic==2.11.7",
     "typing-extensions==4.14.1",
-    "openai==1.99.1",
+    "openai==1.99.3",
     "setuptools==80.9.0",
 ]
 requires-python = ">=3.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-litellm==1.75.0
+litellm[proxy]==1.75.2
 tiktoken==0.10.0
 tenacity==9.1.2
-anthropic==0.61.0
+anthropic==0.62.0
 tomli==2.2.1
 jiter==0.10.0
 pydantic==2.11.7
 typing-extensions==4.14.1
-openai==1.99.1
+openai==1.99.3
 setuptools==80.9.0


### PR DESCRIPTION
### **PR Type**
Feature, Dependencies

___

### **PR Description**
- Added support for new LLM models `gpt-5-2025-08-07` and `claude-opus-4-1-20250805`.
  * Included in temperature, reasoning, and developer message model sets.

- Updated default configuration to use `gpt-5-2025-08-07` as primary model.
  * Switched provider to `openai` and updated fallback configuration.

- Updated dependencies:
  * Updated `litellm` from `1.75.0` to `1.75.2` with proxy support.
  * Updated `anthropic` from `0.61.0` to `0.62.0`.
  * Updated `openai` from `1.99.1` to `1.99.3`.

- Bumped version to `0.3.3` in project files.
